### PR TITLE
Submodule and few changes to help packaging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "rnnoise"]
+	path = rnnoise
+	url = https://github.com/xiph/rnnoise

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install lv2 meson ninja pkg-config autoconf m4 libtool; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool python3.6-dev libmysqlclient-dev; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install --upgrade pip; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install meson; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install lv2 meson ninja pkg-config autoconf m4 libtool; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool libmysqlclient-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install --upgrade pip; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install meson; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install lv2 meson ninja pkg-config autoconf m4 libtool; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool python3-dev libmysqlclient-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool libmysqlclient-dev; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install --upgrade pip; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install meson; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install lv2 meson ninja pkg-config autoconf m4 libtool; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool python3.6-dev libmysqlclient-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool python3-dev libmysqlclient-dev; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install --upgrade pip; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install meson; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq lv2-dev python3-pip ninja-build autoconf m4 libtool; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install --upgrade pip; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo pip3 install meson; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo -H pip3 install meson; fi
 
 script:
   - chmod +x install.sh && ./install.sh

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ To compile and install this plug-in you will need the LV2 SDK, Meson build syste
 Installation 
 -----
 ```bash
-  git clone https://github.com/lucianodato/speech-denoiser.git
-  cd speech-denoiser 
+  git clone --recursive https://github.com/CrocoDuckoDucks/speech-denoiser.git
+  cd speech-denoiser
   chmod +x install.sh && ./install.sh
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -12,33 +12,20 @@ case $OS in
   *) ;;
 esac
 
-#Remove static rnnoise build
-if [ -d rnnoise ]; then
-    read -p "Do you want to remove previous rnnoise build? (y/n)?" choice
-    case "$choice" in 
-    y|Y ) rm -rf rnnoise && echo "Previous rnnoise build removed";;
-    n|N ) echo "Previous rnnoise build was not removed";;
-    * ) echo "invalid";;
-    esac
+#build rrnoise statically
+cd rnnoise && ./autogen.sh
+mv ../ltmain.sh ./ && ./autogen.sh #This is weird but otherwise it won't work
+
+if [ $OS = "Mac" ]; then
+    CFLAGS="-fvisibility=hidden -fPIC " \ 
+    ./configure --disable-examples --disable-doc --disable-shared --enable-static        
+elif [ $OS = "Linux" ]; then
+    CFLAGS="-fvisibility=hidden -fPIC -Wl,--exclude-libs,ALL" \
+    ./configure --disable-examples --disable-doc --disable-shared --enable-static
 fi
 
-#only rebuild rnnoise if the user prefers to
-if [ ! -d rnnoise ]; then
-    #build rrnoise statically
-    cd rnnoise && ./autogen.sh
-    mv ../ltmain.sh ./ && ./autogen.sh #This is weird but otherwise it won't work
-
-    if [ $OS = "Mac" ]; then
-        CFLAGS="-fvisibility=hidden -fPIC " \ 
-        ./configure --disable-examples --disable-doc --disable-shared --enable-static        
-    elif [ $OS = "Linux" ]; then
-        CFLAGS="-fvisibility=hidden -fPIC -Wl,--exclude-libs,ALL" \
-        ./configure --disable-examples --disable-doc --disable-shared --enable-static
-    fi
-
-    make -j2
-    cd ..
-fi
+make -j2
+cd ..
 
 #remove previous builds
 rm -rf build || true

--- a/install.sh
+++ b/install.sh
@@ -13,21 +13,19 @@ case $OS in
 esac
 
 #Remove static rnnoise build
-if [ -d rnnoise-master ]; then
+if [ -d rnnoise ]; then
     read -p "Do you want to remove previous rnnoise build? (y/n)?" choice
     case "$choice" in 
-    y|Y ) rm -rf rnnoise-master && echo "Previous rnnoise build removed";;
+    y|Y ) rm -rf rnnoise && echo "Previous rnnoise build removed";;
     n|N ) echo "Previous rnnoise build was not removed";;
     * ) echo "invalid";;
     esac
 fi
 
 #only rebuild rnnoise if the user prefers to
-if [ ! -d rnnoise-master ]; then
+if [ ! -d rnnoise ]; then
     #build rrnoise statically
-    wget https://github.com/xiph/rnnoise/archive/master.zip
-    unzip -o master.zip && rm master.zip
-    cd rnnoise-master && ./autogen.sh
+    cd rnnoise && ./autogen.sh
     mv ../ltmain.sh ./ && ./autogen.sh #This is weird but otherwise it won't work
 
     if [ $OS = "Mac" ]; then

--- a/meson.build
+++ b/meson.build
@@ -10,8 +10,8 @@ src = 'src/sdenoise.c'
 cc = meson.get_compiler('c')
 
 #handling rnnoise static library
-lib_rnnoise = cc.find_library('rnnoise',dirs: meson.current_source_dir() + '/rnnoise-master/.libs/',required : true)
-inc_rnnoise = include_directories('rnnoise-master/include')
+lib_rnnoise = cc.find_library('rnnoise',dirs: meson.current_source_dir() + '/rnnoise/.libs/',required : true)
+inc_rnnoise = include_directories('rnnoise/include')
 
 #dependencies for speech denoise
 m_dep = cc.find_library('m', required : true)

--- a/static_rnnoise.sh
+++ b/static_rnnoise.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 
-rm -rf rnnoise || true
-git clone https://github.com/xiph/rnnoise.git
+# No need for these with submodule
+# rm -rf rnnoise || true
+# git clone https://github.com/xiph/rnnoise.git
 cd rnnoise/
 ./autogen.sh
+mv ../ltmain.sh ./ && ./autogen.sh # Dang, what with this thing
 
 if [ "$(uname)" == "Darwin" ]; then
   CFLAGS="-fvisibility=hidden -fPIC " \ 
@@ -27,4 +29,6 @@ elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
 #   --disable-shared --enable-static
 fi
 
-make -j2
+# Got to remove the -j, as Arch's makepkg uses the user configured one, and that
+# should not be overidden.
+make

--- a/static_rnnoise.sh
+++ b/static_rnnoise.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+rm -rf rnnoise || true
+git clone https://github.com/xiph/rnnoise.git
+cd rnnoise/
+./autogen.sh
+
+if [ "$(uname)" == "Darwin" ]; then
+  CFLAGS="-fvisibility=hidden -fPIC " \ 
+	./configure \
+  --disable-examples --disable-doc \
+	--disable-shared --enable-static        
+elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+  CFLAGS="-fvisibility=hidden -fPIC -Wl,--exclude-libs,ALL" \
+	./configure \
+  --disable-examples --disable-doc \
+  --disable-shared --enable-static
+# elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW32_NT" ]; then
+#     CFLAGS="-fvisibility=hidden -fPIC -Wl,--exclude-libs,ALL" \
+# 	./configure \
+#   --disable-examples --disable-doc \
+#   --disable-shared --enable-static
+# elif [ "$(expr substr $(uname -s) 1 10)" == "MINGW64_NT" ]; then
+#     CFLAGS="-fvisibility=hidden -fPIC -Wl,--exclude-libs,ALL" \
+# 	./configure \
+#   --disable-examples --disable-doc \
+#   --disable-shared --enable-static
+fi
+
+make -j2


### PR DESCRIPTION
Hi!
The latest changes introduced in the install script make the software hard to package for Arch Linux, as PKGBUILD mandate to have build and installation done in two separate steps, in directories that differ from the standard you provide. As such, your install script has to be bypassed.

To make things even easier, and address [this issue](https://github.com/lucianodato/speech-denoiser/issues/2), I also introduced the rnnoise dependency as a submodule. Currently, my AUR package is building from my fork as I find it more convenient.

As for installation script editing, I just did the bare minimal to make possible for an user to install from the fork by using it. I have no idea about how to use meson, but I have the feeling that it should be possible to have meson handling the build of rnnoise, and perhaps that would be the best option, so that meson/ninja can be used directly both from users and packagers with the same ease.